### PR TITLE
Move Numba to extra dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,15 @@ You can now use the package in Python with:
 
 **Congratulations, you are now ready to use the PhiK correlation analyzer library!**
 
+Speedups
+--------
+
+Phi_K can use the Numba JIT library for faster computation of certain operations.
+You can either install Numba separately or use the `numba` extra specifier while installing:
+
+.. code-block:: bash
+
+  $ pip install phik[numba]
 
 Quick run
 =========

--- a/python/phik/simulation.py
+++ b/python/phik/simulation.py
@@ -17,11 +17,21 @@ from typing import Union
 
 import numpy as np
 import pandas as pd
-from numba import jit
 from joblib import Parallel, delayed
 
 from .statistics import get_dependent_frequency_estimates
 from .statistics import get_chi2_using_dependent_frequency_estimates
+
+try:
+    from numba import jit
+except ImportError:
+    def jit(func=None, **kwargs):
+        if func:  # Called without other arguments, just return the function
+            return func
+        # Otherwise return a no-op decorator
+        def decorator(func):
+            return func
+        return decorator
 
 
 @jit

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,14 @@ REQUIREMENTS = [
     'scipy>=1.1.0',
     'pandas>=0.23.4',
     'matplotlib>=2.2.3',
-    'numba>=0.38.1',
-    'joblib>=0.14.1'
+    'joblib>=0.14.1',
 ]
+
+EXTRA_REQUIREMENTS = {
+    'numba': [
+        'numba>=0.38.1',
+    ],
+}
 
 if DEV:
     REQUIREMENTS += TEST_REQUIREMENTS
@@ -114,6 +119,7 @@ def setup_package() -> None:
               NAME.lower(): ['data/*', 'notebooks/phik_tutorial*.ipynb']
           },
           install_requires=REQUIREMENTS,
+          extras_require=EXTRA_REQUIREMENTS,
           tests_require=TEST_REQUIREMENTS,
           ext_modules=EXTERNAL_MODULES,
           cmdclass=CMD_CLASS,


### PR DESCRIPTION
It is only used by the `phik.simulation` module anyway, and by the looks of it, that module can well (if slowly) run without Numba too.