### PR TITLE
Protect against potential divsion by zero error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Phi_K Correlation Analyzer Library
 ==================================
 
-* Version: 0.11.1. Released: Feb 2021
+* Version: 0.11.2. Released: Mar 2021
 * Documentation: https://phik.readthedocs.io
 * Repository: https://github.com/kaveio/phik
 * Publication: `[offical] <https://www.sciencedirect.com/science/article/abs/pii/S0167947320301341>`_ `[arxiv pre-print] <https://arxiv.org/abs/1811.11440>`_

--- a/python/phik/binning.py
+++ b/python/phik/binning.py
@@ -94,14 +94,7 @@ def bin_data(data: pd.DataFrame, cols: Union[list, np.ndarray, tuple]=(), bins:U
             if col not in bins:
                 raise ValueError('column {0} is not included in bins dictionary.'.format(col))
 
-    # check for numeric bins
-    for col in list(set(data._get_numeric_data().columns) - set(cols)):
-        nuq = data[col].nunique()
-        if (nuq > 0.9 * len(data)) or (nuq > 100):
-            warnings.warn(
-                "numeric variable {1:s} has {0:d} unique values. Are you sure you don't want to bin it?".format(nuq, str(col)),
-                Warning
-            )
+    # MB 20210307: check for numeric bins turned off here, also done in dq_check_nunique_values().
 
     binned_data = data.copy()
 

--- a/python/phik/data_quality.py
+++ b/python/phik/data_quality.py
@@ -48,13 +48,15 @@ def dq_check_nunique_values(df: pd.DataFrame, interval_cols: list, dropna:bool=T
     :param bool dropna: remove NaN values when True
     :returns: cleaned data, updated list of interval columns
     """
+    # check for existing columns
+    interval_cols = [col for col in interval_cols if col in df.columns]
 
     # check non-interval variable for number of unique values
     for col in sorted(list(set(df.columns)-set(interval_cols))):
-        if df[col].nunique() > 100:
+        if df[col].nunique() > 1000:
             warnings.warn(
-                'The number of unique values of variable {0:s} is very large: {1:d}. Are you sure this is '
-                'not an interval variable? Analysis for pairs of variables including {0:s} might be slow.'
+                'The number of unique values of variable {0:s} is large: {1:d}. Are you sure this is '
+                'not an interval variable? Analysis for pairs of variables including {0:s} can be slow.'
                 .format(col, df[col].nunique())
             )
 
@@ -106,13 +108,13 @@ def dq_check_hist2d(hist2d: np.ndarray) -> bool:
             'Too few unique values for variable x ({0:d}) or y ({1:d})'.format(hist2d.shape[0], hist2d.shape[1])
         )
         return False
-    if hist2d.shape[0] > 100:
+    if hist2d.shape[0] > 1000:
         warnings.warn(
             'The number of unique values of variable x is large: {0:d}. '
             'Are you sure this is not an interval variable? Analysis might be slow.'
             .format(hist2d.shape[0])
         )
-    if hist2d.shape[1] > 100:
+    if hist2d.shape[1] > 1000:
         warnings.warn(
             'The number of unique values of variable y is large: {0:d}. '
             'Are you sure this is not an interval variable? Analysis might be slow.'

--- a/python/phik/phik.py
+++ b/python/phik/phik.py
@@ -356,8 +356,8 @@ def phik_from_binned_array(x: Union[np.ndarray, pd.Series], y: Union[np.ndarray,
         y = pd.Series(y).fillna(defs.NaN).astype(str).values
 
     if drop_underflow or drop_overflow:
-        x = x.copy()
-        y = y.copy()
+        x = pd.Series(x).astype(str).values
+        y = pd.Series(y).astype(str).values
         if drop_underflow:
             x[np.where(x == defs.UF)] = np.nan
             y[np.where(y == defs.UF)] = np.nan

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ NAME = 'phik'
 
 MAJOR = 0
 REVISION = 11
-PATCH = 1
+PATCH = 2
 DEV = False
 
 # note: also update README.rst


### PR DESCRIPTION
Protect against potential divsion by zero error in chi2 calculation,
which can happen when there are two variables with 1000+ bins.
See: https://github.com/KaveIO/PhiK/issues/20