### PR TITLE
BUG: Corrects a problem occurring when passing numpy floats or ints to bin_data bins argument

### DIFF
--- a/phik/binning.py
+++ b/phik/binning.py
@@ -115,20 +115,25 @@ def bin_data(
 
     bins_dict = {}
     for col in cols:
-        if np.issubdtype(type(bins), np.integer) or np.issubdtype(type(bins), np.floating):
+        if np.issubdtype(type(bins), np.integer) or np.issubdtype(
+            type(bins), np.floating
+        ):
             xbins = bin_edges(data[col].astype(float), int(bins), quantile=quantile)
         elif isinstance(bins, dict):
-            if np.issubdtype(type(bins[col]), np.integer) or np.issubdtype(type(bins[col]), np.floating):
+            if np.issubdtype(type(bins[col]), np.integer) or np.issubdtype(
+                type(bins[col]), np.floating
+            ):
                 xbins = bin_edges(
                     data[col].astype(float), int(bins[col]), quantile=quantile
                 )
             elif isinstance(bins[col], (list, np.ndarray)):
                 xbins = bins[col]
         elif xbins is None:
-            raise ValueError("Unexpected type for bins. The found type was '%s'" % str(type(bins)))
+            raise ValueError(
+                "Unexpected type for bins. The found type was '%s'" % str(type(bins))
+            )
 
         binned_data[col], bin_labels = bin_array(data[col].astype(float).values, xbins)
-
         if retbins:
             bins_dict[col] = bin_labels
 

--- a/phik/binning.py
+++ b/phik/binning.py
@@ -99,7 +99,7 @@ def bin_data(
     :returns: rebinned DataFrame
     :rtype: pandas.DataFrame
     """
-
+    xbins = None
     if isinstance(bins, dict):
         for col in cols:
             if col not in bins:
@@ -115,16 +115,20 @@ def bin_data(
 
     bins_dict = {}
     for col in cols:
-        if isinstance(bins, (int, float)):
+        if np.issubdtype(type(bins), np.integer) or np.issubdtype(type(bins), np.floating):
             xbins = bin_edges(data[col].astype(float), int(bins), quantile=quantile)
         elif isinstance(bins, dict):
-            if isinstance(bins[col], (int, float)):
+            if np.issubdtype(type(bins[col]), np.integer) or np.issubdtype(type(bins[col]), np.floating):
                 xbins = bin_edges(
                     data[col].astype(float), int(bins[col]), quantile=quantile
                 )
             elif isinstance(bins[col], (list, np.ndarray)):
                 xbins = bins[col]
+        elif xbins is None:
+            raise ValueError("Unexpected type for bins. The found type was '%s'" % str(type(bins)))
+
         binned_data[col], bin_labels = bin_array(data[col].astype(float).values, xbins)
+
         if retbins:
             bins_dict[col] = bin_labels
 

--- a/tests/phik_python/test_phik.py
+++ b/tests/phik_python/test_phik.py
@@ -21,7 +21,7 @@ import pandas as pd
 import numpy as np
 from phik import resources, bivariate
 from phik.simulation import sim_2d_data_patefield
-from phik.binning import auto_bin_data
+from phik.binning import auto_bin_data, bin_data
 from phik.phik import phik_observed_vs_expected_from_rebinned_df, phik_from_hist2d
 from phik.statistics import get_dependent_frequency_estimates
 
@@ -325,3 +325,21 @@ class PhiKTest(unittest.TestCase):
         mean0, mean1 = res.mean(1)
         self.assertTrue(np.isclose(mean0, 105.46))
         self.assertTrue(np.isclose(mean1, 91.18))
+
+    def test_binning_bin_data_bins_tyes(self):
+        # Non regression test
+        # https://github.com/KaveIO/PhiK/issues/28
+        df = pd.DataFrame({"x": np.random.randn(10)})
+        bins_int = np.arange(5, 11, 1)
+        bins_float = np.arange(5, 11, 1.0)
+        bins_dict_int = {"x": np.uint8(10)}
+        bins_dict_float = {"x": np.float32(10.3)}
+
+        for bins in bins_int:
+            bin_data(df, cols=["x"], bins=bins)
+
+        for bins in bins_float:
+            bin_data(df, cols=["x"], bins=bins)
+
+        bin_data(df, cols=["x"], bins=bins_dict_int)
+        bin_data(df, cols=["x"], bins=bins_dict_float)


### PR DESCRIPTION
This PR closes #28 

It does three things:

* Ensures that xbins has been created to avoid the use of the variable when none of the tested types were used
* Modifies the conditions for floats and ints so that it accepts numpy floats and ints
* Added a non regression test