### PR TITLE
add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+---
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    # Check for updates once a day
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: all
+  - package-ecosystem: github-actions
+    directory: /
+    # Check for updates once a week
+    schedule:
+      interval: weekly


### PR DESCRIPTION
This PR adds a dependabot configuration to keep python dependencies and GitHub actions up to date.

You can read more about this feature at https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates.

GitHub also provides a feature to get security update PRs via dependabot: https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/about-managing-vulnerable-dependencies

Continuation of #34 