### PR TITLE
Source distribution fix and Apple silicone wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,24 +11,14 @@ on:
       - published
 
 jobs:
-  build_sdist:
-    name: Build SDist
+  make_sdist:
+    name: Make SDist
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: true
-
-    - uses: actions/setup-python@v3
-
-    - name: Install deps
-      run: python -m pip install twine build
 
     - name: Build SDist
-      run: python -m build -s
-
-    - name: Check metadata
-      run: twine check dist/*
+      run: pipx run build --sdist
 
     - uses: actions/upload-artifact@v2
       with:
@@ -78,14 +68,10 @@ jobs:
         path: wheelhouse/*.whl
 
   upload_all:
-    name: Upload if release
-    needs: [build_wheels, build_sdist]
+    needs: [build_wheels, make_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
-
     steps:
-    - uses: actions/setup-python@v3
-
     - uses: actions/download-artifact@v2
       with:
         name: artifact

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -51,6 +51,7 @@ jobs:
         CIBW_TEST_EXTRAS: test
         CIBW_TEST_COMMAND: pytest {project}/tests/phik_python/test_phik.py
         CIBW_ARCHS: "auto64"
+        CIBW_ARCHS_MACOS: "x86_64 arm64"
         # Skip 32-bit builds
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_x86_64"
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
 Release notes
 =============
 
+Version 0.12.2, Mar 2022
+------------------------
+
+- Fix missing setup.py and pyproject.toml in source distribution
+- Support wheels ARM MacOS (Apple silicone)
+
 Version 0.12.1, Mar 2022
 ------------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,8 @@ include NOTICE
 include LICENSE
 include CMakeLists.txt
 include phik/simcore/CMakeLists.txt
+include pyproject.toml
+include setup.py
 recursive-include phik *.hpp
 recursive-include phik *.cpp
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Phi_K Correlation Analyzer Library
 ==================================
 
-* Version: 0.12.1. Released: Mar 2022
+* Version: 0.12.2. Released: Mar 2022
 * Release notes: https://github.com/KaveIO/PhiK/blob/master/CHANGES.rst
 * Repository: https://github.com/kaveio/phik
 * Documentation: https://phik.readthedocs.io

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ NAME = 'phik'
 
 MAJOR = 0
 REVISION = 12
-PATCH = 1
+PATCH = 2
 DEV = False
 
 # note: also update README.rst, CHANGES.rst


### PR DESCRIPTION
## Fix

- Explicitly added `setup.py` and `pyproject.toml` to `MANIFEST.in`

Fixes #48 

## Enhancements

- Add wheels for MacOS arm64 architecture