### PR TITLE
fix pandas warning

### DIFF
--- a/phik/phik.py
+++ b/phik/phik.py
@@ -196,7 +196,7 @@ def _calc_phik(
     if c0 == c1:
         return c0, c1, 1.0
 
-    datahist = data_binned.groupby([c0, c1])[c0].count().to_frame().unstack().fillna(0)
+    datahist = data_binned.groupby([c0, c1], observed=False)[c0].count().to_frame().unstack().fillna(0)
 
     # If 0 or only 1 values for one of the two variables, it is not possible to calculate phik.
     # This check needs to be done after creation of OF, UF and NaN bins.


### PR DESCRIPTION
Currently the groupby raises a warning by pandas as the default behavior will change

From pandas documentation:

> observed : bool, default False
> This only applies if any of the groupers are Categoricals. If True: only show observed values for categorical groupers. If False: show all values for categorical groupers.
> 
> Deprecated since version 2.1.0: The default value will change to True in a future version of pandas.

To retain the old behavior we need to set `observed=False` which also fixes the warning