### PR TITLE
FIX: numpy random multinomial requires integer number of samples

### DIFF
--- a/phik/simulation.py
+++ b/phik/simulation.py
@@ -35,7 +35,7 @@ def sim_2d_data(hist:np.ndarray, ndata:int=0) -> np.ndarray:
     """
 
     if ndata <= 0:
-        ndata = int(np.round(hist.sum()))
+        ndata = int(np.rint(hist.sum()))
     if ndata <= 0:
         raise ValueError('ndata (or hist.sum()) has to be positive')
 

--- a/phik/simulation.py
+++ b/phik/simulation.py
@@ -35,7 +35,7 @@ def sim_2d_data(hist:np.ndarray, ndata:int=0) -> np.ndarray:
     """
 
     if ndata <= 0:
-        ndata = hist.sum()
+        ndata = int(np.round(hist.sum()))
     if ndata <= 0:
         raise ValueError('ndata (or hist.sum()) has to be positive')
 


### PR DESCRIPTION
Fix for python 3.11 in nixos:
https://github.com/KaveIO/PhiK/issues/73