### PR TITLE
[fix]: migrate from scipy mvn to qmvn functions

### DIFF
--- a/.github/workflows/test_matrix.yml
+++ b/.github/workflows/test_matrix.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Release notes
 =============
 
+Version 0.12.5, Jul 2025
+------------------------
+
+- FIX: scipy 1.16.0 no longer supports mvn, code now migrated to qmvn.
+  https://github.com/KaveIO/PhiK/issues/101
+  https://github.com/KaveIO/PhiK/pull/102
+- Drop support for Python 3.8, has reached end of life.
+
 Version 0.12.4, Jan 2024
 ------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Phi_K Correlation Constant
 ==========================
 
-* Version: 0.12.4. Released: Jan 2024
+* Version: 0.12.5. Released: Jul 2025
 * Release notes: https://github.com/KaveIO/PhiK/blob/master/CHANGES.rst
 * Repository: https://github.com/kaveio/phik
 * Documentation: https://phik.readthedocs.io

--- a/phik/simcore/__init__.py
+++ b/phik/simcore/__init__.py
@@ -1,6 +1,10 @@
 import importlib.util
 
-_ext_spec = importlib.util.find_spec("phik.lib._phik_simulation_core")
+try:
+    _ext_spec = importlib.util.find_spec("phik.lib._phik_simulation_core")
+except ModuleNotFoundError:
+    _ext_spec = None
+
 if _ext_spec is not None:
     from phik.lib._phik_simulation_core import _sim_2d_data_patefield
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,16 +4,15 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "phik"
-version = "0.12.4"
+version = "0.12.5"
 description = "Phi_K correlation analyzer library"
 readme = "README.rst"
 authors = [{ name = "KPMG N.V. The Netherlands", email = "kave@kpmg.com" }]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 4 - Beta",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/tests/test_phik.py
+++ b/tests/test_phik.py
@@ -20,7 +20,7 @@ import pytest
 import pandas as pd
 import numpy as np
 from phik import resources, bivariate
-from phik.simulation import sim_2d_data_patefield
+from phik.simulation import sim_2d_data_patefield, CPP_SUPPORT
 from phik.binning import auto_bin_data, bin_data
 from phik.phik import phik_observed_vs_expected_from_rebinned_df, phik_from_hist2d
 from phik.statistics import get_dependent_frequency_estimates
@@ -309,6 +309,7 @@ class PhiKTest(unittest.TestCase):
 
         self.assertTrue(isinstance(om, dict))
 
+    @pytest.mark.skipif(not CPP_SUPPORT, reason="cpp not supported")
     def test_simulation_2d_patefield(self):
         """Test simulation code using patefield algorithm."""
         og_state = np.random.get_state()

--- a/tests/test_phik.py
+++ b/tests/test_phik.py
@@ -51,7 +51,7 @@ class PhiKTest(unittest.TestCase):
         observed = df[cols].hist2d(interval_cols=interval_cols)
 
         phik_value = phik_from_hist2d(observed)
-        self.assertAlmostEqual(phik_value, 0.7685888294891855)
+        self.assertAlmostEqual(phik_value, 0.7685888294891855, places=3)
 
     def test_phik_observed_vs_expected_from_hist2d(self):
         """Test the calculation of Phi_K value from hist2d"""
@@ -67,7 +67,7 @@ class PhiKTest(unittest.TestCase):
         expected = get_dependent_frequency_estimates(observed)
 
         phik_value = phik_from_hist2d(observed=observed, expected=expected)
-        self.assertAlmostEqual(phik_value, 0.7685888294891855)
+        self.assertAlmostEqual(phik_value, 0.7685888294891855, places=3)
 
     def test_phik_matrix(self):
         """Test the calculation of Phi_K"""
@@ -79,29 +79,25 @@ class PhiKTest(unittest.TestCase):
         interval_cols = ["driver_age", "mileage"]
         phik_corr = df.phik_matrix(interval_cols=interval_cols)
 
-        self.assertTrue(
-            np.isclose(
-                phik_corr.values[cols.index("car_color"), cols.index("area")],
-                0.5904561614620166,
-            )
+        self.assertAlmostEqual(
+            phik_corr.values[cols.index("car_color"), cols.index("area")],
+            0.5904561614620166,
+            places=3,
         )
-        self.assertTrue(
-            np.isclose(
-                phik_corr.values[cols.index("area"), cols.index("car_color")],
-                0.5904561614620166,
-            )
+        self.assertAlmostEqual(
+            phik_corr.values[cols.index("area"), cols.index("car_color")],
+            0.5904561614620166,
+            places=3,
         )
-        self.assertTrue(
-            np.isclose(
-                phik_corr.values[cols.index("mileage"), cols.index("car_size")],
-                0.768588987856336,
-            )
+        self.assertAlmostEqual(
+            phik_corr.values[cols.index("mileage"), cols.index("car_size")],
+            0.768588987856336,
+            places=3,
         )
-        self.assertTrue(
-            np.isclose(
-                phik_corr.values[cols.index("car_size"), cols.index("mileage")],
-                0.768588987856336,
-            )
+        self.assertAlmostEqual(
+            phik_corr.values[cols.index("car_size"), cols.index("mileage")],
+            0.768588987856336,
+            places=3,
         )
 
     def test_phik_matrix_observed_vs_expected(self):
@@ -154,9 +150,9 @@ class PhiKTest(unittest.TestCase):
         car_size = (np.where(gk[1] == "car_size"))[0][0]
         mileage = (np.where(gk[1] == "mileage"))[0][0]
 
-        self.assertTrue(np.isclose(gk[0][area][0], 0.6057528003711345))
-        self.assertTrue(np.isclose(gk[0][car_size][0], 0.76858883))
-        self.assertTrue(np.isclose(gk[0][mileage][0], 0.768588987856336))
+        self.assertAlmostEqual(gk[0][area][0], 0.6057528003711345, places=3)
+        self.assertAlmostEqual(gk[0][car_size][0], 0.76858883, places=3)
+        self.assertAlmostEqual(gk[0][mileage][0], 0.768588987856336, places=3)
 
     def test_significance_matrix_asymptotic(self):
         """Test significance calculation"""


### PR DESCRIPTION
Migrate from scipy mvn to qmvn functions for bivariate normal integration. Needed for scipy >= 1.16.0.