### PR TITLE
Fixes matrix invertability check in global phik method

### DIFF
--- a/phik/phik.py
+++ b/phik/phik.py
@@ -310,7 +310,7 @@ def global_phik_from_rebinned_df(
     )
     V = phik_overview.values
     # check if V is ill-conditioned
-    if (np.linalg.det(V) > 0) and (np.linalg.cond(V) < 1/np.finfo(V.dtype).eps):
+    if (1. / np.linalg.cond(V) > np.finfo(V.dtype).eps):
         Vinv = inv(V)
     else:
         # use pseudo inverse to try handle finite but ill-conditioned arrays;

--- a/phik/phik.py
+++ b/phik/phik.py
@@ -310,7 +310,7 @@ def global_phik_from_rebinned_df(
     )
     V = phik_overview.values
     # check if V is ill-conditioned
-    if np.linalg.cond(V) > np.finfo(V.dtype).eps:
+    if (np.linalg.det(V) > 0) and (np.linalg.cond(V) < 1/np.finfo(V.dtype).eps):
         Vinv = inv(V)
     else:
         # use pseudo inverse to try handle finite but ill-conditioned arrays;


### PR DESCRIPTION
Currently, some ill-conditioned matrices are not caught by the invertability check which leads to 

LinAlgError: singular matrix

during global_phik calculation.

This PR introduces both determinant and condition check.